### PR TITLE
Update rocket.py

### DIFF
--- a/rocket/rocket.py
+++ b/rocket/rocket.py
@@ -140,7 +140,7 @@ setuptools.setup(
             for file in extract_python_files_from_folder(package_dir):
                 files.append(file)
 
-        project_files = ["setup.py", "pyproject.toml"]
+        project_files = ["setup.py", "pyproject.toml", "README.md"]
         for project_file in project_files:
             if os.path.exists(f"{project_location}/{project_file}"):
                 files.append(f"{project_location}/{project_file}")


### PR DESCRIPTION
There seems to be an issue when the pyproject.toml of the repo mentions the README.md.

When installing the package in the notebook, the README.md is not found (because this file is not copied over when running rocket launch) and the installation fails. 

Commenting out the README.md in the pyproject.toml fixes this, but would be good to make sure that this file is copied over with rocket launch command to prevent this issue.