### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - uses: actions/checkout@v3
       - name: Build and publish to pypi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
