### PR TITLE
add uc volumes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog db-rocket
 
+## Version 2.1.1
+- Add `use_volumes` and `dst_path` arguments to support uploading to Unity Catalog Volumes.
+
 ## Version 2.1.0
 - New paramter for ``rocket launch --glob_path=<...>``, which allows to specify a list of globs for files to deploy during launch. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog db-rocket
 
-## Version 2.1.1
+## Version 2.2.0
 - Add `use_volumes` and `dst_path` arguments to support uploading to Unity Catalog Volumes.
 
 ## Version 2.1.0

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ stevenmi@MacBook db-rocket % rocket launch --watch=False
 - Databricks: >=7
 - Python: >=3.7
 - Tested on Platform: Linux, MacOs. Windows will probably not work but contributions are welcomed!
+- Supports uploading to Unity Catalog Volumes starting from version 3.0.0. Note that the underlying dependency, `databricks-sdk`, is still in beta. We do not recommend using UC Volumes in production.
 
 ## Acknowledgments
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ mypy
 SecretStorage
 readme-renderer
 twine
+databricks-sdk==0.33.0

--- a/rocket/rocket.py
+++ b/rocket/rocket.py
@@ -299,7 +299,7 @@ and following in a new Python cell:
 
     def get_volumes_path(self, path: Optional[str]) -> str:
         if path and not path.startswith("/Volumes"):
-            raise Exception("`volumes_path` must start with /Volumes")
+            raise Exception("`use_volumes` is true. `dst_path` must start with /Volumes")
         return path or f"/Volumes/main/data_products/volume/db_rocket/{os.environ['USER']}"
 
     def get_install_path(self, db_path):

--- a/rocket/rocket.py
+++ b/rocket/rocket.py
@@ -293,8 +293,10 @@ and following in a new Python cell:
         return wheel_path, wheel_file
 
     def get_dbfs_path(self, path: Optional[str]) -> str:
-        if path and not self.is_dbfs(path):
-            raise Exception("`dbfs_path` must start with dbfs:/")
+        if path:
+            logger.warning("The `dbfs_path` parameter is planned for deprecation. Please use the `dst_path` parameter instead.")
+            if not self.is_dbfs(path):
+                raise Exception("`dbfs_path` must start with dbfs:/")
         return path or f"dbfs:/temp/{os.environ['USER']}"
 
     def get_volumes_path(self, path: Optional[str]) -> str:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except Exception as e:
 
 setuptools.setup(
     name="databricks-rocket",
-    version="2.1.0",
+    version="2.1.1",
     author="GetYourGuide",
     author_email="engineering.data-products@getyourguide.com",
     description="Keep your local python scripts installed and in sync with a databricks notebook. Shortens the feedback loop to develop projects using a hybrid enviroment",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except Exception as e:
 
 setuptools.setup(
     name="databricks-rocket",
-    version="2.2.0",
+    version="3.0.0",
     author="GetYourGuide",
     author_email="engineering.data-products@getyourguide.com",
     description="Keep your local python scripts installed and in sync with a databricks notebook. Shortens the feedback loop to develop projects using a hybrid enviroment",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except Exception as e:
 
 setuptools.setup(
     name="databricks-rocket",
-    version="2.1.1",
+    version="2.2.0",
     author="GetYourGuide",
     author_email="engineering.data-products@getyourguide.com",
     description="Keep your local python scripts installed and in sync with a databricks notebook. Shortens the feedback loop to develop projects using a hybrid enviroment",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/getyourguide/db-rocket",
     packages=setuptools.find_packages(),
-    install_requires=["fire", "watchdog~=2.1.9", "build", "databricks_cli"],
+    install_requires=["fire", "watchdog~=2.1.9", "build", "databricks_cli", "databricks-sdk==0.33.0"],
     entry_points={
         "console_scripts": ["rocket=rocket.rocket:main", "dbrocket=rocket.rocket:main"]
     },


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please ensure your pull request title uses following pattern:
 - JIRA_TICKET_ID DESCRIPTIVE_SUMMARY_OF_CHANGES 
 - Example: RR-2582 Remove All Bugs From Service

Please ensure you've done the following:  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible. If your PR is large, try to split it in order to make it more readable.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 👨‍💻👩‍💻 Please make sure your code is clean and readable by adding code documentation, using meaningful variables, and follows our coding standards (https://docs.google.com/document/d/1PGWRq_aFHxcxoz9n-38HmGMKeJwjHAnSApO2dQhlwCs/edit#heading=h.25vo55dea18c)

⚠️ Note: Pull Requests are a feedback seeking mechanism, not to remove errors. You do not need approvals for merging!
-->

## Description

<!--
Please include a summary of the code changes. Please also link your JIRA ticket if it exists. Further, please include post-deployment tasks that need to be performed in order to deploy your changes e.g. triggering a airflow DAG, update OpenAPI schema, ….
-->
This PR enables support for uploading to Volumes.

Issue:
After migrating to tropic3.5, we can not correctly install projects in the cluster due to permission issues (see [here](https://getyourguide.slack.com/archives/C02KBPF2FTP/p1727419107303429) and [here](https://getyourguide.slack.com/archives/C3TGR1FB5/p1727705780894539)). The [release notes](https://docs.databricks.com/en/release-notes/runtime/15.1.html#storing-libraries-in-dbfs-root-is-deprecated-and-disabled-by-default) indicate that storing libraries in DBFS root is deprecated and disabled by default and it is recommended to use Unity Catalog Volumes.

We could resolve this issue by uploading our projects to /Volumes. However, only Databricks CLI versions above 0.214.0 [support](https://github.com/sonatype/databricks-cli/blob/main/CHANGELOG.md#02140) interaction with Volumes; otherwise, it raises an `Authorization failed. Your token may be expired or lack the valid scope` error. The current [databricks-cli](https://pypi.org/project/databricks-cli/) is version 0.18 and won't be updated further. One of our options is to use the databricks-sdk, which is still in beta phase. During integration, I found the SDK's functionality to be lacking, but it can still unblock us from using a cluster with Unity Catalog enabled. 

The default path of upload is [here](https://dbc-d10db17d-b6c4.cloud.databricks.com/explore/data/volumes/main/data_products/volume?o=4592942032988138&volumePath=%2FVolumes%2Fmain%2Fdata_products%2Fvolume%2Fdb_rocket%2F).

[notebook](https://dbc-d10db17d-b6c4.cloud.databricks.com/?o=4592942032988138#notebook/2791524185520385/command/2791524185520586) of installing ranking in tropic3.5


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed

## Added to documentation?

- [ ] 👍 README.md
- [ ] 👍 CHANGELOG.md
- [ ] 👍 Additional documentation in /docs
- [ ] 👍 Relevant code documentation
- [ ] 🙅 no, because they aren’t needed
