### PR TITLE
Change logic on token via env variable not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog db-rocket
 
+## Version 3.0.3
+- Add warning when DATABRICKS_TOKEN is set rather than failing when its not set. The bulk of our use-cases rely on the token being set via databricks configure command. The token via environment variable is only used for CI and we should treat as an edge case.
+
 ## Version 3.0.2
 - Add databricks cli configuration check
 

--- a/rocket/rocket.py
+++ b/rocket/rocket.py
@@ -73,8 +73,8 @@ setuptools.setup(
         if not os.path.exists(f"{home}/.databrickscfg"):
             raise Exception("Databricks cli not configured. Run `databricks configure --token`.")
 
-        if os.getenv("DATABRICKS_TOKEN") is None:
-            raise Exception("DATABRICKS_TOKEN must be set for db-rocket to work")
+        if os.getenv("DATABRICKS_TOKEN"):
+            print("Note: DATABRICKS_TOKEN is set, it could override the token in ~/.databrickscfg and cause errors.")
 
         base_dbfs_access_error_message = ("Is your databricks token is set and valid? "
                                           "Try to generate a new token and update existing one with "

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except Exception as e:
 
 setuptools.setup(
     name="databricks-rocket",
-    version="3.0.2",
+    version="3.0.3",
     author="GetYourGuide",
     author_email="engineering.data-products@getyourguide.com",
     description="Keep your local python scripts installed and in sync with a databricks notebook. Shortens the feedback loop to develop projects using a hybrid enviroment",

--- a/tests/resources/poetry-test/pyproject.toml
+++ b/tests/resources/poetry-test/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-test"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Steven Mi <steven.mi@getyourguide.com>"]
 

--- a/tests/resources/poetry-test/pyproject.toml
+++ b/tests/resources/poetry-test/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-test"
-version = "0.1.1"
+version = "0.1.0"
 description = ""
 authors = ["Steven Mi <steven.mi@getyourguide.com>"]
 


### PR DESCRIPTION
- Add warning when DATABRICKS_TOKEN is set rather than failing when its not set. The bulk of our use-cases rely on the token being set via databricks configure command. The token via environment variable is only used for CI and we should treat as an edge case.

