### PR TITLE
fix: remove faulty error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog db-rocket
 
+## Version 3.0.5
+- Revert enforcing the creation of .databrickscfg file
+
 ## Version 3.0.3
 - Add warning when DATABRICKS_TOKEN is set rather than failing when its not set. The bulk of our use-cases rely on the token being set via databricks configure command. The token via environment variable is only used for CI and we should treat as an edge case.
 

--- a/rocket/rocket.py
+++ b/rocket/rocket.py
@@ -70,9 +70,6 @@ setuptools.setup(
         """
 
         home = os.environ['HOME']
-        if not os.path.exists(f"{home}/.databrickscfg"):
-            raise Exception("Databricks cli not configured. Run `databricks configure --token`.")
-
         if os.getenv("DATABRICKS_TOKEN"):
             print("Note: DATABRICKS_TOKEN is set, it could override the token in ~/.databrickscfg and cause errors.")
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except Exception as e:
 
 setuptools.setup(
     name="databricks-rocket",
-    version="3.0.4",
+    version="3.0.5",
     author="GetYourGuide",
     author_email="engineering.data-products@getyourguide.com",
     description="Keep your local python scripts installed and in sync with a databricks notebook. Shortens the feedback loop to develop projects using a hybrid enviroment",


### PR DESCRIPTION
Latest changes enforces .databrickscfg which requires extra step for devcontainer which is not necessary. Removing it to cause compatibility with other environments